### PR TITLE
Fix unpacking in list append for compatibility

### DIFF
--- a/script/particle_filtering_model_predictive_control.py
+++ b/script/particle_filtering_model_predictive_control.py
@@ -223,10 +223,10 @@ def main():
 
         time = time + dt
 
-        x.append(state.x)
-        y.append(state.y)
-        yaw.append(state.yaw)
-        v.append(state.v)
+        x.append(*state.x)
+        y.append(*state.y)
+        yaw.append(*state.yaw)
+        v.append(*state.v)
         t.append(time)
 
         if show_animation:  # pragma: no cover


### PR DESCRIPTION
related issue
https://github.com/rsasaki0109/particle_filtering_model_predictive_control/issues/1

bafore
```
~/workspace/particle_filtering_model_predictive_control$ python3 script/particle_filtering_model_predictive_control.py 
Particle filtering model predictive control simulation start
$HOME/.local/lib/python3.10/site-packages/numpy/core/shape_base.py:65: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  ary = asanyarray(ary)
$HOME/.local/lib/python3.10/site-packages/numpy/core/shape_base.py:65: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  ary = asanyarray(ary)
...
```
after
```
~/workspace/particle_filtering_model_predictive_control$ python3 script/particle_filtering_model_predictive_control.py 
Particle filtering model predictive control simulation start
```